### PR TITLE
hotfix: inviteCode 길이 제한

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,9 @@ dependencies {
 
     //validation
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    //NanoId
+    implementation 'com.aventrix.jnanoid:jnanoid:2.0.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/pico/server/service/InviteCodeService.java
+++ b/src/main/java/com/pico/server/service/InviteCodeService.java
@@ -10,11 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
-import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -25,7 +25,7 @@ public class InviteCodeService {
     @Transactional
     public String makeInviteCode(Long userId) {
         validateCouple(userId);
-        String inviteCode = UUID.randomUUID().toString();
+        String inviteCode = NanoIdUtils.randomNanoId(NanoIdUtils.DEFAULT_NUMBER_GENERATOR,NanoIdUtils.DEFAULT_ALPHABET, 10);
         String key = "inviteCode:" + inviteCode;
 
         Set<String> keys = redisTemplate.keys("inviteCode:*");


### PR DESCRIPTION
# 📌 개요
- UUID를 통해 36자리로 생성하던 초대코드를 NanoId를 활용해 10자리로 줄였습니다.
  
# 💻 작업사항

# ❌ 주의사항