### PR TITLE
hotfix: repeatType 변수명 통일

### DIFF
--- a/src/main/java/com/pico/server/dto/request/CreateScheduleDto.java
+++ b/src/main/java/com/pico/server/dto/request/CreateScheduleDto.java
@@ -31,7 +31,7 @@ public record CreateScheduleDto(
     @NotNull
     Boolean isRepeat,
     @Schema(description = "일정 반복 주기", example = "WEEKLY")
-    RepeatType repeat
+    RepeatType repeatType
 ) {
 
 }

--- a/src/main/java/com/pico/server/dto/request/UpdateScheduleDto.java
+++ b/src/main/java/com/pico/server/dto/request/UpdateScheduleDto.java
@@ -24,7 +24,7 @@ public record UpdateScheduleDto(
     @Schema(description = "반복 일정 여부", example = "true")
     Boolean isRepeat,
     @Schema(description = "일정 반복 주기", example = "WEEKLY")
-    RepeatType repeat
+    RepeatType repeatType
 ) {
 
 }


### PR DESCRIPTION
# 📌 개요
- 입력때와 출력때의 repeatType의 변수명이 달라 통일 시키는 작업을 진행했습니다.
  
# 💻 작업사항

# ❌ 주의사항