### PR TITLE
[SVR-8] 유저 정보 조회시 파트너 이름 추가

### DIFF
--- a/src/main/java/com/pico/server/dto/UserInfoDto.java
+++ b/src/main/java/com/pico/server/dto/UserInfoDto.java
@@ -24,13 +24,13 @@ public record UserInfoDto(
 
     @Nullable
     Long partnerId,
-
+    @Nullable
+    String partnerName,
     @Nullable
     String partnerNickname,
 
     @Nullable
     String partnerProfileImage,
-
     Boolean isTermsAgreed,
     Boolean isMarketingAgreed
 ) {
@@ -45,6 +45,7 @@ public record UserInfoDto(
             .birth(userDetails.getBirth().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
             .dday(userDetails.getDday().format(DateTimeFormatter.ofPattern("yyyy-MM-dd")))
             .partnerId(userDetails.getPartnerId())
+            .partnerName(userDetails.getPartnerName())
             .partnerNickname(userDetails.getPartnerNickname())
             .partnerProfileImage(userDetails.getPartnerProfileImage())
             .isTermsAgreed(userDetails.getIsTermsAgreed())

--- a/src/main/java/com/pico/server/entity/UserDetails.java
+++ b/src/main/java/com/pico/server/entity/UserDetails.java
@@ -32,6 +32,7 @@ public class UserDetails {
     private Long partnerId;
     private String partnerNickname;
     private String partnerProfileImage;
+    private String partnerName;
 
     @Enumerated(EnumType.STRING)
     private Gender gender;
@@ -46,10 +47,11 @@ public class UserDetails {
     private Boolean isTermsAgreed;
     private Boolean isMarketingAgreed;
 
-    public void updatePartnerInfo(Long partnerId, String partnerNickname, String partnerProfileImage) {
+    public void updatePartnerInfo(Long partnerId, String partnerNickname, String partnerProfileImage, String partnerName) {
         this.partnerId = partnerId;
         this.partnerNickname = partnerNickname;
         this.partnerProfileImage = partnerProfileImage;
+        this.partnerName = partnerName;
     }
 
     public void updateUserInfo(Gender gender, String nickName, LocalDate birth, LocalDate dday,Boolean isTermsAgreed, Boolean isMarketingAgreed) {

--- a/src/main/java/com/pico/server/service/InviteCodeService.java
+++ b/src/main/java/com/pico/server/service/InviteCodeService.java
@@ -59,8 +59,8 @@ public class InviteCodeService {
         Users partner = userRepository.findById(partnerUserId)
             .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
 
-        user.getUserDetails().updatePartnerInfo(partner.getId(), partner.getUserDetails().getNickName(), partner.getProfileImage());
-        partner.getUserDetails().updatePartnerInfo(userId, user.getUserDetails().getNickName(), user.getProfileImage());
+        user.getUserDetails().updatePartnerInfo(partner.getId(), partner.getUserDetails().getNickName(), partner.getProfileImage(), partner.getName());
+        partner.getUserDetails().updatePartnerInfo(userId, user.getUserDetails().getNickName(), user.getProfileImage(), user.getName());
         userRepository.save(user);
         userRepository.save(partner);
 


### PR DESCRIPTION
# 📌 개요
- 유저 정보 조회시에 파트너 id, 닉네임, 이미지와 함께 이름을 함께 가지고올 수 있도록 entity 및 dto 수정을 진행했습니다.
  
# 💻 작업사항
- [x] userDetails partnerName 추가 및 조회 로직 추가 구현

# ❌ 주의사항