### PR TITLE
[SVR-9] 오늘 일정만 수정 로직 추가

### DIFF
--- a/src/main/java/com/pico/server/controller/ScheduleApi.java
+++ b/src/main/java/com/pico/server/controller/ScheduleApi.java
@@ -67,6 +67,16 @@ public interface ScheduleApi {
         @RequestBody UpdateScheduleDto updateScheduleDto
     );
 
+    @PostMapping("/update/only/{scheduleId}")
+    @Operation(summary = "오늘 일정만 수정", description = "기존의 반복 일정은 그대로두고 요청날짜의 일정만 변경합니다.")
+    ResponseEntity<ScheduleResponse> updateOnlyToday(
+        @Parameter(hidden = true)
+        @LoginUserId Long userId,
+        @PathVariable("scheduleId") Long scheduleId,
+        @RequestBody UpdateScheduleDto updateScheduleDto
+    );
+
+
     @GetMapping("/get/detail/{scheduleId}")
     @Operation(summary = "단일 세부 일정 조회", description = "한 일정의 세부 일정을 조회합니다.")
     ResponseEntity<ScheduleResponse> getOneSchedule(

--- a/src/main/java/com/pico/server/controller/impl/ScheduleController.java
+++ b/src/main/java/com/pico/server/controller/impl/ScheduleController.java
@@ -50,6 +50,14 @@ public class ScheduleController implements ScheduleApi {
     }
 
     @Override
+    public ResponseEntity<ScheduleResponse> updateOnlyToday(Long userId, Long scheduleId,
+        UpdateScheduleDto updateScheduleDto) {
+        ScheduleDto scheduleDto = scheduleService.updateOnlyTodaySchedule(userId, scheduleId, updateScheduleDto);
+        ScheduleResponse response = ScheduleResponse.of(true, scheduleDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
     public ResponseEntity<ScheduleResponse> getOneSchedule(Long userId, Long scheduleId) {
         ScheduleDto scheduleDto = scheduleService.getOneSchedule(userId, scheduleId);
         ScheduleResponse response = ScheduleResponse.of(true, scheduleDto);

--- a/src/main/java/com/pico/server/entity/Schedule.java
+++ b/src/main/java/com/pico/server/entity/Schedule.java
@@ -57,4 +57,5 @@ public class Schedule extends BaseEntity{
     public void deleteRepeatInfo() {
         this.repeatInfo = null;
     }
+
 }

--- a/src/main/java/com/pico/server/service/ScheduleService.java
+++ b/src/main/java/com/pico/server/service/ScheduleService.java
@@ -80,6 +80,46 @@ public class ScheduleService {
     }
 
     @Transactional
+    public ScheduleDto updateOnlyTodaySchedule(Long userId, Long scheduleId, UpdateScheduleDto updateDto) {
+        //original schedule entTime 변경
+        Schedule schedule = scheduleRepository.findByUserIdAndScheduleId(userId, scheduleId)
+            .orElseThrow(() -> new ScheduleException(ErrorCode.NOT_FOUND_SCHEDULE));
+
+        Users user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+
+        RepeatInfo originalRepeatInfo = schedule.getRepeatInfo();
+        originalRepeatInfo.updateRepeatEndDate(LocalDateTime.now().minusDays(1).with(LocalTime.of(23,59)));
+        repeatInfoRepository.save(originalRepeatInfo);
+        scheduleRepository.save(schedule);
+
+        //변경된 schedule 생성
+        RepeatInfo changedRepeatInfo = createRepeatInfo(updateDto.startTime(), updateDto.repeatType());
+        Schedule changedSchdule = Schedule.builder()
+            .user(user)
+            .title(updateDto.title())
+            .category(updateDto.category())
+            .startTime(updateDto.startTime())
+            .endTime(updateDto.endTime())
+            .isAllDay(updateDto.isAllDay())
+            .isRepeat(updateDto.isRepeat())
+            .meetingPeople(updateDto.meetingPeople())
+            .repeatInfo(changedRepeatInfo)
+            .build();
+        repeatInfoRepository.save(changedRepeatInfo);
+        scheduleRepository.save(changedSchdule);
+
+        //new Origin 스케줄 생성
+        LocalDateTime newStartTime = checkNextStartTime(originalRepeatInfo);
+        RepeatInfo repeatInfo = createRepeatInfo(newStartTime, originalRepeatInfo.getRepeatType());
+        Schedule newOriginSchedule = makeOriginSchedule(schedule, repeatInfo, newStartTime);
+        repeatInfoRepository.save(repeatInfo);
+        scheduleRepository.save(newOriginSchedule);
+
+        return ScheduleDto.from(changedSchdule);
+    }
+
+    @Transactional
     public ScheduleDto updateSchedule(Long userId, Long scheduleId, UpdateScheduleDto updateDto) {
         Schedule schedule = scheduleRepository.findByUserIdAndScheduleId(userId, scheduleId)
             .orElseThrow(() -> new ScheduleException(ErrorCode.NOT_FOUND_SCHEDULE));
@@ -202,6 +242,7 @@ public class ScheduleService {
             .build();
     }
 
+
     private boolean isRecurringScheduleWithinRange(Schedule schedule, LocalDateTime weekStart, LocalDateTime weekEnd) {
         RepeatInfo repeatInfo = schedule.getRepeatInfo();
         if (repeatInfo == null) {
@@ -246,5 +287,44 @@ public class ScheduleService {
         return false;
     }
 
+    private Schedule makeOriginSchedule(Schedule schedule, RepeatInfo repeatInfo, LocalDateTime startTime) {
+        return Schedule.builder()
+            .user(schedule.getUser())
+            .title(schedule.getTitle())
+            .category(schedule.getCategory())
+            .startTime(startTime)
+            .endTime(schedule.getEndTime())
+            .isAllDay(schedule.getIsAllDay())
+            .isRepeat(schedule.getIsRepeat())
+            .meetingPeople(schedule.getMeetingPeople())
+            .repeatInfo(repeatInfo)
+            .build();
+    }
+
+    private LocalDateTime checkNextStartTime(RepeatInfo repeatInfo) {
+        RepeatType repeatType = repeatInfo.getRepeatType();
+        LocalDateTime currentDate = repeatInfo.getRepeatStartDate();
+
+        switch (repeatType) {
+            case DAILY:
+                currentDate = currentDate.plusDays(1);
+                break;
+            case WEEKLY:
+                currentDate = currentDate.plusWeeks(1);
+                break;
+            case MONTHLY:
+                currentDate = currentDate.plusMonths(1);
+                break;
+            case YEARLY:
+                currentDate = currentDate.plusYears(1);
+                break;
+            case BIWEEKLY:
+                currentDate = currentDate.plusWeeks(2);
+                break;
+            default:
+                throw new ScheduleException(ErrorCode.NOT_FOUND_SCHEDULE);
+        }
+        return currentDate;
+    }
 
 }


### PR DESCRIPTION
# 📌 개요
- 오늘 일정만 수정하고 기존의 반복 일정은 그대로 둬 수정 로직을 세분화했습니다.
  
# 💻 작업사항
- [x] update요청시에 받은 내용을 바탕으로 오늘 날짜의 스케줄 수정 로직 구현
- [x] 기존의 스케줄 내용을 오늘 날짜 전후로 구분해 2가지로 수정 로직 구현

# ❌ 주의사항
- 현재 오늘 날짜만 수정을 진행할경우, 어제까지의 기존 반복일정 / 변경된 요청 날짜의 일정 / 요청 날짜 이후의 기존 반복 일정 3가지로 스케줄을 나눠두었습니다.