### PR TITLE
[SVR-11] 오늘 이후 일정 수정 로직 추가 구현

### DIFF
--- a/src/main/java/com/pico/server/controller/ScheduleApi.java
+++ b/src/main/java/com/pico/server/controller/ScheduleApi.java
@@ -76,6 +76,15 @@ public interface ScheduleApi {
         @RequestBody UpdateScheduleDto updateScheduleDto
     );
 
+    @PostMapping("/update/after/{scheduleId}")
+    @Operation(summary = "오늘 이후 일정 수정", description = "기존의 반복 일정은 그대로두고 요청날짜를 포함한 이후의 일정을 변경합니다.")
+    ResponseEntity<ScheduleResponse> updateAfterToday(
+        @Parameter(hidden = true)
+        @LoginUserId Long userId,
+        @PathVariable("scheduleId") Long scheduleId,
+        @RequestBody UpdateScheduleDto updateScheduleDto
+    );
+
 
     @GetMapping("/get/detail/{scheduleId}")
     @Operation(summary = "단일 세부 일정 조회", description = "한 일정의 세부 일정을 조회합니다.")

--- a/src/main/java/com/pico/server/controller/impl/ScheduleController.java
+++ b/src/main/java/com/pico/server/controller/impl/ScheduleController.java
@@ -58,6 +58,14 @@ public class ScheduleController implements ScheduleApi {
     }
 
     @Override
+    public ResponseEntity<ScheduleResponse> updateAfterToday(Long userId, Long scheduleId,
+        UpdateScheduleDto updateScheduleDto) {
+        ScheduleDto scheduleDto = scheduleService.updateAfterTodaySchedule(userId, scheduleId, updateScheduleDto);
+        ScheduleResponse response = ScheduleResponse.of(true,scheduleDto);
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
     public ResponseEntity<ScheduleResponse> getOneSchedule(Long userId, Long scheduleId) {
         ScheduleDto scheduleDto = scheduleService.getOneSchedule(userId, scheduleId);
         ScheduleResponse response = ScheduleResponse.of(true, scheduleDto);

--- a/src/main/java/com/pico/server/service/ScheduleService.java
+++ b/src/main/java/com/pico/server/service/ScheduleService.java
@@ -182,6 +182,40 @@ public class ScheduleService {
     }
 
     @Transactional
+    public ScheduleDto updateAfterTodaySchedule(Long userId, Long scheduleId, UpdateScheduleDto updateDto) {
+        //original schedule entTime 변경
+        Schedule schedule = scheduleRepository.findByUserIdAndScheduleId(userId, scheduleId)
+            .orElseThrow(() -> new ScheduleException(ErrorCode.NOT_FOUND_SCHEDULE));
+
+        Users user = userRepository.findById(userId)
+            .orElseThrow(() -> new UserException(ErrorCode.NOT_FOUND_USER));
+
+        RepeatInfo originalRepeatInfo = schedule.getRepeatInfo();
+        originalRepeatInfo.updateRepeatEndDate(LocalDateTime.now().minusDays(1).with(LocalTime.of(23,59)));
+        repeatInfoRepository.save(originalRepeatInfo);
+        scheduleRepository.save(schedule);
+
+        //변경된 schedule 생성
+        RepeatInfo changedRepeatInfo = createRepeatInfo(updateDto.startTime(), updateDto.repeatType());
+        Schedule changedSchdule = Schedule.builder()
+            .user(user)
+            .title(updateDto.title())
+            .category(updateDto.category())
+            .startTime(updateDto.startTime())
+            .endTime(updateDto.endTime())
+            .isAllDay(updateDto.isAllDay())
+            .isRepeat(updateDto.isRepeat())
+            .isAnniversary(false)
+            .meetingPeople(updateDto.meetingPeople())
+            .repeatInfo(changedRepeatInfo)
+            .build();
+        repeatInfoRepository.save(changedRepeatInfo);
+        scheduleRepository.save(changedSchdule);
+
+        return ScheduleDto.from(changedSchdule);
+    }
+
+    @Transactional
     public ScheduleDto updateSchedule(Long userId, Long scheduleId, UpdateScheduleDto updateDto) {
         Schedule schedule = scheduleRepository.findByUserIdAndScheduleId(userId, scheduleId)
             .orElseThrow(() -> new ScheduleException(ErrorCode.NOT_FOUND_SCHEDULE));


### PR DESCRIPTION
# 📌 개요
- 오늘을 포함한 이후의 일정을 수정하는 로직을 추가했습니다.
  
# 💻 작업사항
- [x] 오늘을 포함해 이후의 일정 수정 로직 구현
- [x] 일정 객체를 분리해 이전의 origin 일정과 수정된 일정 두가지로 나누는 로직 구현

# ❌ 주의사항
- 